### PR TITLE
Add /cheesewho slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Then you’ll need to subscribe the app to a few events. The server has an endpo
 - `message.groups`
 - `reaction_added`
 
+You can optionally create a slash command, `/cheesewho`, that tells the user who has the Cheese Touch!. Point it to the URL `https://<SERVER>/slack/cheesewho`
+
 ### Environment variables
 
 Here are all the variables you need to set up, with hints.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/go-redis/redis v6.15.8+incompatible
-	github.com/joho/godotenv v1.3.0 // indirect
+	github.com/joho/godotenv v1.3.0
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/slack-go/slack v0.6.5
 )

--- a/pkg/cheese/server.go
+++ b/pkg/cheese/server.go
@@ -11,6 +11,17 @@ import (
 	"github.com/slack-go/slack/slackevents"
 )
 
+type slashCommandResponse struct {
+	Blocks       slack.Blocks `json:"blocks,omitempty"`
+	Text         string       `json:"text,omitempty"`
+	ResponseType string       `json:"response_type,omitempty"`
+}
+
+func (resp slashCommandResponse) MarshalJSON() []byte {
+	marshalled, _ := json.Marshal(resp)
+	return marshalled
+}
+
 var (
 	cheeseConfig *Config
 	redisClient  *redis.Client
@@ -31,7 +42,8 @@ func StartServer(config *Config) {
 
 	// Start receiving events
 	http.HandleFunc("/slack/events", handleSlackEvents)
-	http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", config.Port), nil)
+	http.HandleFunc("/slack/cheesewho", handleSlashCommand)
+	http.ListenAndServe(fmt.Sprintf(":%d", config.Port), nil)
 }
 
 func handleSlackEvents(w http.ResponseWriter, r *http.Request) {
@@ -63,4 +75,35 @@ func handleSlackEvents(w http.ResponseWriter, r *http.Request) {
 		HandleInnerEvent(slackClient, &apiEvent.InnerEvent)
 		break
 	}
+}
+
+func handleSlashCommand(w http.ResponseWriter, r *http.Request) {
+	command, _ := slack.SlashCommandParse(r)
+	bearerOfCheese := WhoHasCheeseTouch()
+
+	var text string
+
+	if bearerOfCheese == "" {
+		text = "Looks like nobody has the Cheese Touch... yet... :cheese_wedge:"
+	} else if bearerOfCheese == command.UserID {
+		text = "Oh no, _you_ have the Cheese Touch! :cheese_wedge: Give it to someone else by posting :point_up: after their message!"
+	} else {
+		text = fmt.Sprintf("Looks like <@%s> has the Cheese Touch right now! :cheese_wedge:", bearerOfCheese)
+	}
+
+	blocks := slack.Blocks{
+		BlockSet: []slack.Block{
+			slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", text, false, false), nil, nil),
+		},
+	}
+
+	resp := slashCommandResponse{
+		ResponseType: "ephemeral",
+		Blocks:       blocks,
+	}
+
+	marshalled := resp.MarshalJSON()
+
+	w.Header().Add("Content-type", "application/json")
+	w.Write(marshalled)
 }

--- a/pkg/cheese/server.go
+++ b/pkg/cheese/server.go
@@ -79,6 +79,13 @@ func handleSlackEvents(w http.ResponseWriter, r *http.Request) {
 
 func handleSlashCommand(w http.ResponseWriter, r *http.Request) {
 	command, _ := slack.SlashCommandParse(r)
+
+	if !command.ValidateToken(cheeseConfig.VerificationToken) {
+		w.WriteHeader(400)
+		w.Write([]byte("Request not verified."))
+		return
+	}
+
 	bearerOfCheese := WhoHasCheeseTouch()
 
 	var text string
@@ -86,7 +93,7 @@ func handleSlashCommand(w http.ResponseWriter, r *http.Request) {
 	if bearerOfCheese == "" {
 		text = "Looks like nobody has the Cheese Touch... yet... :cheese_wedge:"
 	} else if bearerOfCheese == command.UserID {
-		text = "Oh no, _you_ have the Cheese Touch! :cheese_wedge: Give it to someone else by posting :point_up: after their message!"
+		text = "Oh no, _you_ have the Cheese Touch! :cheese_wedge: Give it to someone else by reacting to their message with :point_up:!"
 	} else {
 		text = fmt.Sprintf("Looks like <@%s> has the Cheese Touch right now! :cheese_wedge:", bearerOfCheese)
 	}

--- a/pkg/cheese/utils.go
+++ b/pkg/cheese/utils.go
@@ -52,6 +52,16 @@ func HasCheeseTouch(userId string) bool {
 	return bearingUserId == userId
 }
 
+func WhoHasCheeseTouch() string {
+	bearingUserId, err := redisClient.Get("bearing_user_id").Result()
+
+	if err != nil {
+		return ""
+	}
+
+	return bearingUserId
+}
+
 func HasCheeseTouchStarted() bool {
 	exists, err := redisClient.Exists("bearing_user_id").Result()
 


### PR DESCRIPTION
This PR adds a slash command, `/cheesewho`, that lets people know who has the Cheese Touch. Maybe the person is supposed to be anonymous, so I'll be fine with it if this isn't merged. :man_shrugging: 

You'll need to add a slash command in the Slack app settings, `/cheesewho` (name isn't important) that points to the URL `https://<idk server url>/slack/cheesewho`